### PR TITLE
Cleanup & Fixes on xp0-double

### DIFF
--- a/xp0-double/README.txt
+++ b/xp0-double/README.txt
@@ -1,0 +1,5 @@
+This deploys a XP deployment with a CM and CD (but no reporting or processing instance like XP-full uses)
+
+For this template to work, you need an XP0 CM web deploy package, and an XP1 CD web deploy package for the two web apps. In other words you need aspects of both the XP0 and XP1 packages Sitecore provides.
+
+(or you can make your own templates with the Azure Toolkit)

--- a/xp0-double/README.txt
+++ b/xp0-double/README.txt
@@ -2,4 +2,10 @@ This deploys a XP deployment with a CM and CD (but no reporting or processing in
 
 For this template to work, you need an XP0 CM web deploy package, and an XP1 CD web deploy package for the two web apps. In other words you need aspects of both the XP0 and XP1 packages Sitecore provides.
 
+NOTE: This script expects a customized version of the XP0 CM web deploy package with these additional Web Deploy parameters added:
+IP Security Client IP
+IP Security Client IP Mask
+
+Using a stock XP0 package will result in errors; you can also remove those parameters from line ~194 in the msdeploy.json template if you want to be compatible with stock XP0.
+
 (or you can make your own templates with the Azure Toolkit)

--- a/xp0-double/run-infra.ps1
+++ b/xp0-double/run-infra.ps1
@@ -2,6 +2,7 @@
 $ArmTemplatePath = "$($PSScriptRoot)\xp0d-azuredeploy-infra.json";
 $ArmParametersPath = "$($PSScriptRoot)\xp0d-azuredeploy-infra.parameters.json";
 
+$ErrorActionPreference = 'Stop'
 $Name = "YOUR_RESOURCE_GROUP_NAME";
 $location = "West Europe";
 $AzureSubscriptionId = "YOUR_SUBSCRIPTION_ID";
@@ -51,12 +52,10 @@ try {
         #region Use Manual Login
         try 
         {
-            Write-Host "inside try"
             Set-AzureRmContext -SubscriptionID $AzureSubscriptionId
         }
         catch 
         {
-            Write-Host "inside catch"
             Login-AzureRmAccount
             Set-AzureRmContext -SubscriptionID $AzureSubscriptionId
         }
@@ -71,12 +70,11 @@ try {
         New-AzureRmResourceGroup -Name $Name -Location $location;
     }
 
-    Write-Verbose "Starting ARM deployment...";
+    Write-Host "Starting ARM deployment...";
     New-AzureRmResourceGroupDeployment `
         -Name "sitecore-infra" `
-        -ResourceGroupName `
-        $Name -TemplateFile `
-        $ArmTemplatePath `
+        -ResourceGroupName $Name `
+        -TemplateFile $ArmTemplatePath `
         -TemplateParameterObject $additionalParams;
         # -DeploymentDebugLogLevel All -Debug;
 

--- a/xp0-double/run-msdeploy.ps1
+++ b/xp0-double/run-msdeploy.ps1
@@ -2,6 +2,8 @@
 $ArmTemplatePath = "$($PSScriptRoot)\xp0d-azuredeploy-msdeploy.json";
 $ArmParametersPath = "$($PSScriptRoot)\xp0d-azuredeploy-msdeploy.parameters.json";
 
+$ErrorActionPreference = 'Stop'
+
 # read the contents of your Sitecore license file
 $licenseFileContent = Get-Content -Raw -Encoding UTF8 -Path "$($PSScriptRoot)\license.xml" | Out-String;
 $Name = "YOUR_RESOURCE_GROUP_NAME";
@@ -90,12 +92,10 @@ try {
         #region Use Manual Login
         try 
         {
-            Write-Host "inside try"
             Set-AzureRmContext -SubscriptionID $AzureSubscriptionId
         }
         catch 
         {
-            Write-Host "inside catch"
             Login-AzureRmAccount
             Set-AzureRmContext -SubscriptionID $AzureSubscriptionId
         }
@@ -116,7 +116,7 @@ try {
     $sitecoreDeploymentOutputAsJson =  ConvertTo-Json $sitecoreDeploymentOutput -Depth 5
     $sitecoreDeploymentOutputAsHashTable = ConvertPSObjectToHashtable $(ConvertFrom-Json $sitecoreDeploymentOutputAsJson)
 
-    Write-Verbose "Starting ARM deployment...";
+    Write-Host "Starting ARM deployment...";
     New-AzureRmResourceGroupDeployment `
         -Name "sitecore-msdeploy" `
         -ResourceGroupName $Name `

--- a/xp0-double/run-redeploy.ps1
+++ b/xp0-double/run-redeploy.ps1
@@ -2,6 +2,8 @@
 $ArmTemplatePath = "$($PSScriptRoot)\xp0d-azuredeploy-msdeploy.json";
 $ArmParametersPath = "$($PSScriptRoot)\xp0d-azuredeploy-redeploy.parameters.json";
 
+$ErrorActionPreference = 'Stop'
+
 # read the contents of your Sitecore license file
 $licenseFileContent = Get-Content -Raw -Encoding UTF8 -Path "$($PSScriptRoot)\license.xml" | Out-String;
 $Name = "YOUR_RESOURCE_GROUP_NAME";
@@ -90,12 +92,10 @@ try {
         #region Use Manual Login
         try 
         {
-            Write-Host "inside try"
             Set-AzureRmContext -SubscriptionID $AzureSubscriptionId
         }
         catch 
         {
-            Write-Host "inside catch"
             Login-AzureRmAccount
             Set-AzureRmContext -SubscriptionID $AzureSubscriptionId
         }
@@ -116,7 +116,7 @@ try {
     $sitecoreDeploymentOutputAsJson =  ConvertTo-Json $sitecoreDeploymentOutput -Depth 5
     $sitecoreDeploymentOutputAsHashTable = ConvertPSObjectToHashtable $(ConvertFrom-Json $sitecoreDeploymentOutputAsJson)
 
-    Write-Verbose "Starting ARM deployment...";
+    Write-Host "Starting ARM deployment...";
     New-AzureRmResourceGroupDeployment `
         -Name "sitecore-msdeploy" `
         -ResourceGroupName $Name `

--- a/xp0-double/xp0d-azuredeploy-infra.json
+++ b/xp0-double/xp0d-azuredeploy-infra.json
@@ -237,10 +237,6 @@
         "provider": "b51535c2-ab3e-4a68-95f8-e2e3c9a19299"
       }
     },
-    "rep.authentication.apikey": {
-      "type": "securestring",
-      "minLength": 32
-    },
     "sitecoreSKU" : {
       "type" : "string",
       "defaultValue": "xP1",

--- a/xp0-double/xp0d-azuredeploy-infra.parameters.json
+++ b/xp0-double/xp0d-azuredeploy-infra.parameters.json
@@ -2,9 +2,6 @@
   "deploymentId": {
     "value": ""
   },
-  "rep.authentication.apikey": {
-	"value": ""
-  },
   "analytics.mongodb.connectionstring": {
     "value": ""
   },

--- a/xp0-double/xp0d-azuredeploy-msdeploy.json
+++ b/xp0-double/xp0d-azuredeploy-msdeploy.json
@@ -116,18 +116,6 @@
       "minLength": 8,
       "defaultValue": "[concat(toUpper(uniqueString('cd-web')), '@', uniqueString(parameters('sqlserver_password')))]"
     },
-    "analytics_mongodb_connectionstring": {
-      "type": "securestring"
-    },
-    "tracking_live_mongodb_connectionstring": {
-      "type": "securestring"
-    },
-    "tracking_history_mongodb_connectionstring": {
-      "type": "securestring"
-    },
-    "tracking_contact_mongodb_connectionstring": {
-      "type": "securestring"
-    },
     "licenseXml": {
       "type": "securestring"
     },

--- a/xp0-double/xp0d-azuredeploy-msdeploy.json
+++ b/xp0-double/xp0d-azuredeploy-msdeploy.json
@@ -190,7 +190,9 @@
                   "Application Insights Instrumentation Key": "[reference(concat('Microsoft.Resources/deployments/', 'sitecore-infra'), '2015-11-01').outputs.appInsightsInstrumentationKey.value]",
                   "Application Insights Role": "CM",
                   "KeepAlive Url": "[concat('https://', reference(resourceId('Microsoft.Web/sites', variables('cmWebAppNameTidy'))).hostNames[0], '/sitecore/service/keepalive.aspx')]",
-                  "License Xml": "[variables('licenseXml')]"
+                  "License Xml": "[variables('licenseXml')]",
+                  "IP Security Client IP": "[parameters('security_clientIp')]",
+                  "IP Security Client IP Mask": "[parameters('security_clientIpMask')]"
                 }
               }
             }

--- a/xp0-double/xp0d-azuredeploy-msdeploy.json
+++ b/xp0-double/xp0d-azuredeploy-msdeploy.json
@@ -190,9 +190,7 @@
                   "Application Insights Instrumentation Key": "[reference(concat('Microsoft.Resources/deployments/', 'sitecore-infra'), '2015-11-01').outputs.appInsightsInstrumentationKey.value]",
                   "Application Insights Role": "CM",
                   "KeepAlive Url": "[concat('https://', reference(resourceId('Microsoft.Web/sites', variables('cmWebAppNameTidy'))).hostNames[0], '/sitecore/service/keepalive.aspx')]",
-                  "License Xml": "[variables('licenseXml')]",
-                  "IP Security Client IP": "[parameters('security_clientIp')]",
-                  "IP Security Client IP Mask": "[parameters('security_clientIpMask')]"
+                  "License Xml": "[variables('licenseXml')]"
                 }
               }
             }

--- a/xp0-double/xp0d-azuredeploy-msdeploy.parameters.json
+++ b/xp0-double/xp0d-azuredeploy-msdeploy.parameters.json
@@ -2,18 +2,6 @@
   "sitecore_admin_password": {
     "value": ""
   },
-  "analytics_mongodb_connectionstring": {
-    "value": ""
-  },
-  "tracking_live_mongodb_connectionstring": {
-    "value": ""
-  },
-  "tracking_history_mongodb_connectionstring": {
-    "value": ""
-  },
-  "tracking_contact_mongodb_connectionstring": {
-    "value": ""
-  },
   "sqlserver_login": {
     "value": ""
   },


### PR DESCRIPTION
I cleaned up a few unused parameters, added `ErrorActionPreference` to make the PowerShells exit on error instead of continue, and added a README with some setup notes specific to xp0-double.

Also removed a CM package param that is not present in the 8.2U3 XP0 package (https://github.com/kamsar/Sitecore-Azure-Scripts/commit/2fe739bcd7ecd37eee78dcc1a0e350b7a12c6ee6)