### PR TITLE
Added support for Key Vault secret references in parameter files

### DIFF
--- a/xp-full/run-infra.ps1
+++ b/xp-full/run-infra.ps1
@@ -6,21 +6,6 @@ $Name = "YOUR_RESOURCE_GROUP_NAME";
 $location = "West Europe";
 $AzureSubscriptionId = "YOUR_SUBSCRIPTION_ID";
 
-#region Create Params Object
-# license file needs to be secure string and adding the params as a hashtable is the only way to do it
-$additionalParams = New-Object -TypeName Hashtable;
-
-$params = Get-Content $ArmParametersPath -Raw | ConvertFrom-Json;
-
-foreach($p in $params | Get-Member -MemberType *Property)
-{
-    $additionalParams.Add($p.Name, $params.$($p.Name).value);
-}
-
-$additionalParams.Set_Item('deploymentId', $Name);
-
-#endregion
-
 #region Service Principle Details
 
 # By default this script will prompt you for your Azure credentials but you can update the script to use an Azure Service Principal instead by following the details at the link below and updating the four variables below once you are done.
@@ -62,6 +47,36 @@ try {
         }
         #endregion      
     }
+
+    #region Create Params Object
+    # license file needs to be secure string and adding the params as a hashtable is the only way to do it
+    $additionalParams = New-Object -TypeName Hashtable;
+
+    $params = Get-Content $ArmParametersPath -Raw | ConvertFrom-Json;
+
+    foreach($p in $params | Get-Member -MemberType *Property)
+    {
+        # Check if the parameter is a reference to a Key Vault secret
+        if (($params.$($p.Name).reference) -and
+            ($params.$($p.Name).reference.keyVault) -and
+            ($params.$($p.Name).reference.keyVault.id) -and
+            ($params.$($p.Name).reference.secretName))
+        {
+            $vaultName = Split-Path $params.$($p.Name).reference.keyVault.id -Leaf
+            $secretName = $params.$($p.Name).reference.secretName
+            $secret = (Get-AzureKeyVaultSecret -VaultName $vaultName -Name $secretName).SecretValue
+
+            $additionalParams.Add($p.Name, $secret);
+        }
+        # Or a normal plaintext parameter
+        else
+        {
+            $additionalParams.Add($p.Name, $params.$($p.Name).value);
+        }
+    }
+
+    $additionalParams.Set_Item('deploymentId', $Name);
+    #endregion
 
     Write-Host "Check if resource group already exists..."
     $notPresent = Get-AzureRmResourceGroup -Name $Name -ev notPresent -ea 0;

--- a/xp0-double/run-infra.ps1
+++ b/xp0-double/run-infra.ps1
@@ -7,21 +7,6 @@ $Name = "YOUR_RESOURCE_GROUP_NAME";
 $location = "West Europe";
 $AzureSubscriptionId = "YOUR_SUBSCRIPTION_ID";
 
-#region Create Params Object
-# license file needs to be secure string and adding the params as a hashtable is the only way to do it
-$additionalParams = New-Object -TypeName Hashtable;
-
-$params = Get-Content $ArmParametersPath -Raw | ConvertFrom-Json;
-
-foreach($p in $params | Get-Member -MemberType *Property)
-{
-    $additionalParams.Add($p.Name, $params.$($p.Name).value);
-}
-
-$additionalParams.Set_Item('deploymentId', $Name);
-
-#endregion
-
 #region Service Principle Details
 
 # By default this script will prompt you for your Azure credentials but you can update the script to use an Azure Service Principal instead by following the details at the link below and updating the four variables below once you are done.
@@ -61,6 +46,36 @@ try {
         }
         #endregion      
     }
+
+    #region Create Params Object
+    # license file needs to be secure string and adding the params as a hashtable is the only way to do it
+    $additionalParams = New-Object -TypeName Hashtable;
+
+    $params = Get-Content $ArmParametersPath -Raw | ConvertFrom-Json;
+
+    foreach($p in $params | Get-Member -MemberType *Property)
+    {
+        # Check if the parameter is a reference to a Key Vault secret
+        if (($params.$($p.Name).reference) -and
+            ($params.$($p.Name).reference.keyVault) -and
+            ($params.$($p.Name).reference.keyVault.id) -and
+            ($params.$($p.Name).reference.secretName))
+        {
+            $vaultName = Split-Path $params.$($p.Name).reference.keyVault.id -Leaf
+            $secretName = $params.$($p.Name).reference.secretName
+            $secret = (Get-AzureKeyVaultSecret -VaultName $vaultName -Name $secretName).SecretValue
+
+            $additionalParams.Add($p.Name, $secret);
+        }
+        # Or a normal plaintext parameter
+        else
+        {
+            $additionalParams.Add($p.Name, $params.$($p.Name).value);
+        }
+    }
+
+    $additionalParams.Set_Item('deploymentId', $Name);
+    #endregion
 
     Write-Host "Check if resource group already exists..."
     $notPresent = Get-AzureRmResourceGroup -Name $Name -ev notPresent -ea 0;

--- a/xp0-double/run-msdeploy.ps1
+++ b/xp0-double/run-msdeploy.ps1
@@ -10,21 +10,6 @@ $Name = "YOUR_RESOURCE_GROUP_NAME";
 $location = "West Europe";
 $AzureSubscriptionId = "YOUR_SUBSCRIPTION_ID";
 
-#region Create Params Object
-# license file needs to be secure string and adding the params as a hashtable is the only way to do it
-$additionalParams = New-Object -TypeName Hashtable;
-
-$params = Get-Content $ArmParametersPath -Raw | ConvertFrom-Json;
-
-foreach($p in $params | Get-Member -MemberType *Property)
-{
-    $additionalParams.Add($p.Name, $params.$($p.Name).value);
-}
-
-$additionalParams.Set_Item('licenseXml', $licenseFileContent);
-
-#endregion
-
 #region Service Principle Details
 
 # By default this script will prompt you for your Azure credentials but you can update the script to use an Azure Service Principal instead by following the details at the link below and updating the four variables below once you are done.
@@ -101,6 +86,36 @@ try {
         }
         #endregion      
     }
+
+    #region Create Params Object
+    # license file needs to be secure string and adding the params as a hashtable is the only way to do it
+    $additionalParams = New-Object -TypeName Hashtable;
+
+    $params = Get-Content $ArmParametersPath -Raw | ConvertFrom-Json;
+
+    foreach($p in $params | Get-Member -MemberType *Property)
+    {
+        # Check if the parameter is a reference to a Key Vault secret
+        if (($params.$($p.Name).reference) -and
+            ($params.$($p.Name).reference.keyVault) -and
+            ($params.$($p.Name).reference.keyVault.id) -and
+            ($params.$($p.Name).reference.secretName))
+        {
+            $vaultName = Split-Path $params.$($p.Name).reference.keyVault.id -Leaf
+            $secretName = $params.$($p.Name).reference.secretName
+            $secret = (Get-AzureKeyVaultSecret -VaultName $vaultName -Name $secretName).SecretValue
+
+            $additionalParams.Add($p.Name, $secret);
+        }
+        # Or a normal plaintext parameter
+        else
+        {
+            $additionalParams.Add($p.Name, $params.$($p.Name).value);
+        }
+    }
+
+    $additionalParams.Set_Item('licenseXml', $licenseFileContent);
+    #endregion
 
     Write-Host "Check if resource group already exists..."
     $notPresent = Get-AzureRmResourceGroup -Name $Name -ev notPresent -ea 0;

--- a/xp0-double/run-redeploy.ps1
+++ b/xp0-double/run-redeploy.ps1
@@ -10,21 +10,6 @@ $Name = "YOUR_RESOURCE_GROUP_NAME";
 $location = "West Europe";
 $AzureSubscriptionId = "YOUR_SUBSCRIPTION_ID";
 
-#region Create Params Object
-# license file needs to be secure string and adding the params as a hashtable is the only way to do it
-$additionalParams = New-Object -TypeName Hashtable;
-
-$params = Get-Content $ArmParametersPath -Raw | ConvertFrom-Json;
-
-foreach($p in $params | Get-Member -MemberType *Property)
-{
-    $additionalParams.Add($p.Name, $params.$($p.Name).value);
-}
-
-$additionalParams.Set_Item('licenseXml', $licenseFileContent);
-
-#endregion
-
 #region Service Principle Details
 
 # By default this script will prompt you for your Azure credentials but you can update the script to use an Azure Service Principal instead by following the details at the link below and updating the four variables below once you are done.
@@ -101,6 +86,36 @@ try {
         }
         #endregion      
     }
+
+    #region Create Params Object
+    # license file needs to be secure string and adding the params as a hashtable is the only way to do it
+    $additionalParams = New-Object -TypeName Hashtable;
+
+    $params = Get-Content $ArmParametersPath -Raw | ConvertFrom-Json;
+
+    foreach($p in $params | Get-Member -MemberType *Property)
+    {
+        # Check if the parameter is a reference to a Key Vault secret
+        if (($params.$($p.Name).reference) -and
+            ($params.$($p.Name).reference.keyVault) -and
+            ($params.$($p.Name).reference.keyVault.id) -and
+            ($params.$($p.Name).reference.secretName))
+        {
+            $vaultName = Split-Path $params.$($p.Name).reference.keyVault.id -Leaf
+            $secretName = $params.$($p.Name).reference.secretName
+            $secret = (Get-AzureKeyVaultSecret -VaultName $vaultName -Name $secretName).SecretValue
+
+            $additionalParams.Add($p.Name, $secret);
+        }
+        # Or a normal plaintext parameter
+        else
+        {
+            $additionalParams.Add($p.Name, $params.$($p.Name).value);
+        }
+    }
+
+    $additionalParams.Set_Item('licenseXml', $licenseFileContent);
+    #endregion
 
     Write-Host "Check if resource group already exists..."
     $notPresent = Get-AzureRmResourceGroup -Name $Name -ev notPresent -ea 0;

--- a/xp0-single/run-infra.ps1
+++ b/xp0-single/run-infra.ps1
@@ -6,21 +6,6 @@ $Name = "YOUR_RESOURCE_GROUP_NAME";
 $location = "West Europe";
 $AzureSubscriptionId = "YOUR_SUBSCRIPTION_ID";
 
-#region Create Params Object
-# license file needs to be secure string and adding the params as a hashtable is the only way to do it
-$additionalParams = New-Object -TypeName Hashtable;
-
-$params = Get-Content $ArmParametersPath -Raw | ConvertFrom-Json;
-
-foreach($p in $params | Get-Member -MemberType *Property)
-{
-    $additionalParams.Add($p.Name, $params.$($p.Name).value);
-}
-
-$additionalParams.Set_Item('deploymentId', $Name);
-
-#endregion
-
 #region Service Principle Details
 
 # By default this script will prompt you for your Azure credentials but you can update the script to use an Azure Service Principal instead by following the details at the link below and updating the four variables below once you are done.
@@ -62,6 +47,36 @@ try {
         }
         #endregion      
     }
+
+    #region Create Params Object
+    # license file needs to be secure string and adding the params as a hashtable is the only way to do it
+    $additionalParams = New-Object -TypeName Hashtable;
+
+    $params = Get-Content $ArmParametersPath -Raw | ConvertFrom-Json;
+
+    foreach($p in $params | Get-Member -MemberType *Property)
+    {
+        # Check if the parameter is a reference to a Key Vault secret
+        if (($params.$($p.Name).reference) -and
+            ($params.$($p.Name).reference.keyVault) -and
+            ($params.$($p.Name).reference.keyVault.id) -and
+            ($params.$($p.Name).reference.secretName))
+        {
+            $vaultName = Split-Path $params.$($p.Name).reference.keyVault.id -Leaf
+            $secretName = $params.$($p.Name).reference.secretName
+            $secret = (Get-AzureKeyVaultSecret -VaultName $vaultName -Name $secretName).SecretValue
+
+            $additionalParams.Add($p.Name, $secret);
+        }
+        # Or a normal plaintext parameter
+        else
+        {
+            $additionalParams.Add($p.Name, $params.$($p.Name).value);
+        }
+    }
+
+    $additionalParams.Set_Item('deploymentId', $Name);
+    #endregion
 
     Write-Host "Check if resource group already exists..."
     $notPresent = Get-AzureRmResourceGroup -Name $Name -ev notPresent -ea 0;


### PR DESCRIPTION
This change allows for referencing Key Vault secrets from within the parameters file. The format is described here: https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-manager-keyvault-parameter#reference-a-secret-with-static-id

The tl:dr is that instead of:

```
{
  "sitecore_admin_password": {
	"value": "LoremIpsum1234"
  }
}
```

the parameter file would reference a secret on the format:

```
{
  "sitecore_admin_password": {
    "reference": {
        "keyVault": {
            "id": "/subscriptions/abc12345-1234-1234-abcd-abc12341234/resourceGroups/the-resource-group/providers/Microsoft.KeyVault/vaults/the-vault-name"
        },
        "secretName": "sitecore-admin-password"
    }
  }
}
```

Please note that the underscore character is not allowed in secret names. Hence the change from sitecore_admin_password to sitecore-admin-password.